### PR TITLE
Avoid destructive substitution in 4.12+ alias

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+### Unreleased
+
+- Avoid destructive substitution in 4.12+ alias to ensure equivalent
+  `Semaphore` signatures. (#1, @CraigFe)
+
 ### 1.0.0 (2020-11-02)
 
 Initial release.

--- a/src/semaphore-as-alias.ml
+++ b/src/semaphore-as-alias.ml
@@ -2,7 +2,7 @@ include (
   Semaphore :
     sig
       module Counting :
-        Semaphore_intf.COUNTING with type t := Semaphore.Counting.t
+        Semaphore_intf.COUNTING with type t = Semaphore.Counting.t
 
-      module Binary : Semaphore_intf.BINARY with type t := Semaphore.Binary.t
+      module Binary : Semaphore_intf.BINARY with type t = Semaphore.Binary.t
     end )


### PR DESCRIPTION
... to ensure that both versions of the library have equivalent signatures.