### PR TITLE
Add `ocaml` dependency

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -15,5 +15,6 @@
 Projects that want to use the Semaphore module defined in OCaml 4.12.0 while
 staying compatible with older versions of OCaml should use this library
 instead.
-"))
-
+")
+ (depends
+  ocaml))

--- a/semaphore-compat.opam
+++ b/semaphore-compat.opam
@@ -14,6 +14,7 @@ doc: "https://mirage.github.io/semaphore-compat"
 bug-reports: "https://github.com/mirage/semaphore-compat/issues"
 depends: [
   "dune" {>= "2.0"}
+  "ocaml"
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
Dune package management is a bit more strict about dependencies, thus packages without an `ocaml` dependency don't have access to an OCaml compiler.

This PR adds the dependency.

This change is also submitted for existing releases to opam-repository: https://github.com/ocaml/opam-repository/pull/26610